### PR TITLE
feat: animation added on progressBar

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
             <div class="wrap-skill">
   						<h5 class="invert-color">JavaScript</h5>
   						<div class="progress progress-frame skill-level">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" id='js'>
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">100%</span>
   						    </div>
   						</div>
@@ -62,7 +62,7 @@
             <div class="wrap-skill">
   						<h5 class="invert-color">HTML & CSS</h5>
   						<div class="progress progress-frame skill-level">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" id='html'>
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">100%</span>
   						    </div>
   						</div>
@@ -70,7 +70,7 @@
             <div class="wrap-skill">
   						<h5 class="invert-color">Creativity</h5>
   						<div class="progress progress-frame skill-level">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" id='creativity'>
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">90%</span>
   						    </div>
   						</div>
@@ -78,7 +78,7 @@
             <div class="wrap-skill">
   						<h5 class="invert-color">Time Management</h5>
   						<div class="progress progress-frame skill-level">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" id='time-mng'>
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">100%</span>
   						    </div>
   						</div>
@@ -86,7 +86,7 @@
             <div class="wrap-skill">
   						<h5 class="invert-color">Leadership</h5>
   						<div class="progress progress-frame skill-level">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" id='leadership'>
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">80%</span>
   						    </div>
   						</div>
@@ -94,7 +94,7 @@
   					<div class="wrap-skill">
   						<h5 class="invert-color">written & verbal communication</h5>
   						<div class="progress progress-frame">
-  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" id="comm">
+  						    <div class="progress-bar progress-bar-custom" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100">
   						        <span class="sr-only">70%</span>
   						    </div>
   						</div>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,8 @@
+window.onload = function(){
+  var progressBars = document.querySelectorAll('div[role="progressbar"]');
+  var width;
+  progressBars.forEach(function(progressBarObject){
+    width = progressBarObject.getAttribute('aria-valuenow');
+    progressBarObject.style.width = width + '%';
+  });
+}


### PR DESCRIPTION
firslty ids are removed from html file as the are no longer required because the
role attribute is common among all divs of progress bar. So I am just getting a
html collection of all progressbar objects and looking at their aria-valuenow
attribute to get the width of each progressbar object.